### PR TITLE
Switch to cross-compilation for `linux_aarch64` and `linux_ppc64le`

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - vs2019
 c_stdlib:
 - vs
+c_stdlib_version:
+- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: 4b5be4ad11ded8c33e83f757435a6c3fa5ff309339b13e18da9f520fb349bf3b  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or aarch64 or ppc64le]
 
 test:


### PR DESCRIPTION
This PR switches to cross-compilation for `linux_aarch64` and `linux_ppc64le`.

See https://github.com/conda-forge/cuda-feedstock/issues/25
